### PR TITLE
Update Amazon issuer expiration date

### DIFF
--- a/pst-issuers.json
+++ b/pst-issuers.json
@@ -33,7 +33,7 @@
 		"name": "Amazon Ads issuer",
 		"contact": "amazon-ads-pst-issuer@amazon.com",
 		"endpoint": "https://www.amazon.com/tt/k",
-		"expiry": "1772575200"
+		"expiry": "1788800400"
 	},
 	"https://pst-issuer.clearsale.com.br": {
 		"name": "Clearsale Anti Fraud",


### PR DESCRIPTION
Set Amazon issuer expiration to 1788800400, which is Monday, September 7, 2026 5:00:00 PM GMT.

Fixes Issue #40.
