### PR TITLE
Update Contentpass issuer expiration date

### DIFF
--- a/pst-issuers.json
+++ b/pst-issuers.json
@@ -51,6 +51,6 @@
 		"name": "Contentpass Issuer",
 		"contact": "ops@contentpass.de",
 		"endpoint": "https://my.contentpass.net/.well-known/trust-token/key-commitment",
-		"expiry": "1773878399"
+		"expiry": "1787615999"
 	}
 }


### PR DESCRIPTION
Set Contentpass issuer expiration to 1787615999, which is Monday, August 24, 2026 11:59:59 PM GMT.